### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/apps/common/models/Checkout/Fraud.php
+++ b/apps/common/models/Checkout/Fraud.php
@@ -13,7 +13,7 @@ class Fraud  extends \Libs\Stupy\Model {
 		} else {
 			/*
 			maxmind api
-			http://www.maxmind.com/app/ccv
+			https://minfraud.maxmind.com/app/ccv
 			
 			paypal api
 			https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_html_IPNandPDTVariables
@@ -44,7 +44,7 @@ class Fraud  extends \Libs\Stupy\Model {
 			$request .= '&order_amount=' . urlencode($this->currency->format($data['total'], $data['currency_code'], $data['currency_value'], false));
 			$request .= '&order_currency=' . urlencode($data['currency_code']);
 		
-			$curl = curl_init('https://minfraud1.maxmind.com/app/ccv2r');
+			$curl = curl_init('https://minfraud.maxmind.com/app/ccv2r');
 			
 			curl_setopt($curl, CURLOPT_HEADER, 0);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)